### PR TITLE
Updated src/batcher/base.py to adapt to mat files and RVHR data

### DIFF
--- a/src/batcher/base.py
+++ b/src/batcher/base.py
@@ -283,6 +283,8 @@ class BaseBatcher:
         ) -> Dict[str, torch.Tensor]:
         out = dict(__key__=sample["__key__"])
         t_r = sample["t_r.pyd"]
+        hr = np.array(sample["hr"]).astype(np.float)
+        rv = np.array(sample["rv"]).astype(np.float)
 
         label = None
         f_s = None
@@ -304,10 +306,22 @@ class BaseBatcher:
 
                 seq_on, seq_len = self._sample_seq_on_and_len(bold_len=len(bold))
                 bold = bold[seq_on:seq_on+seq_len]
+                hr = hr[seq_on:seq_on + seq_len]
+                rv = rv[seq_on:seq_on + seq_len]
                 t_rs = np.arange(seq_len) * t_r
                 attention_mask = np.ones(seq_len)
                 bold = self._pad_seq_right_to_n(
                     seq=bold,
+                    n=self.seq_max,
+                    pad_value=0
+                )
+                hr = self._pad_seq_right_to_n(
+                    seq=hr,
+                    n=self.seq_max,
+                    pad_value=0
+                )
+                rv = self._pad_seq_right_to_n(
+                    seq=rv,
                     n=self.seq_max,
                     pad_value=0
                 )
@@ -321,7 +335,11 @@ class BaseBatcher:
                     n=self.seq_max,
                     pad_value=0
                 )
+                hr = np.squeeze(hr)
+                rv = np.squeeze(rv)
                 out["inputs"] = torch.from_numpy(bold).to(torch.float)
+                out["hr"] = torch.from_numpy(hr).to(torch.float)
+                out["rv"] = torch.from_numpy(rv).to(torch.float)
                 out['t_rs'] = torch.from_numpy(t_rs).to(torch.float)
                 out["attention_mask"] = torch.from_numpy(attention_mask).to(torch.long)
                 out['seq_on'] = seq_on

--- a/src/tools/data.py
+++ b/src/tools/data.py
@@ -11,42 +11,14 @@ def grab_tarfile_paths(path) -> Tuple[str]:
 
     for p in paths:
 
-        if os.path.isdir(
-            os.path.join(
-                path,
-                p
-            )
-        ):
-            tarfiles += [
-                os.path.join(
-                    path,
-                    p,
-                    f
-                )
-                for f in os.listdir(
-                    os.path.join(
-                        path,
-                        p
-                    )
-                )
-                if f.endswith('.tar')
+        if os.path.isdir(os.path.join(path,p)):
+            tarfiles += [os.path.join(path,p,f)
+                for f in os.listdir(os.path.join(path,p))
+                    if f.endswith('.mat')
             ]
 
-        elif np.logical_and(
-            os.path.isfile(
-                os.path.join(
-                    path,
-                    p
-                )
-            ), 
-            p.endswith('.tar')
-        ):
-            tarfiles.append(
-                os.path.join(
-                    path,
-                    p
-                )
-            )
+        elif np.logical_and(os.path.isfile(os.path.join(path,p)), p.endswith('.mat')):
+            tarfiles.append(os.path.join(path,p))
 
     return sorted(np.unique(tarfiles))
 
@@ -63,7 +35,7 @@ def split_tarfile_paths_train_val(
     np.random.seed(seed)
     datasets = np.unique(
         [
-            f.split('/')[-1].split('ds-')[1].split('_')[0]
+            f.split('/')[-1].split('_')[0]
             for f in tarfile_paths
         ]
     )
@@ -74,7 +46,7 @@ def split_tarfile_paths_train_val(
         dataset_tarfiles = np.unique(
             [
                 f for f in tarfile_paths
-                if f'ds-{dataset}' in f
+                if f'{dataset}' in f
             ]
         )
 


### PR DESCRIPTION
1) Updated the src/batcher/base.py file so that a) the script will read .mat files for the resting-fMRI BOLD signal (Schaefer ROIs were used as an example as specified in train.py - default_args.data); b) in addition, it will load physiological files (RV and HR) and save them along with the fMRI time courses
2) Updated the tool/data file to read in mat files